### PR TITLE
Fix git fatal error message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,9 @@ for CURRENT_BRANCH in ${ALL_THE_BRANCHES[@]};
     # the branch is NOT the same as the key branch
     if [ "${KEY_BRANCH}" != "${CURRENT_BRANCH}" ];
     then
+      echo "--GIT FETCH origin"
+      git fetch origin
+      echo "--GIT CHECKOUT -b $CURRENT_BRANCH origin/$CURRENT_BRANCH"
       git checkout -b $CURRENT_BRANCH origin/$CURRENT_BRANCH
 
       # Go through each of the files


### PR DESCRIPTION
I tried to use the action and received the following message:

    fatal: 'origin/gh-pages' is not a commit and a branch 'gh-pages' cannot be created from it

I used in my workflow the following job:

```yaml
  update-docs-on-gh-pages-branch:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
        with:
          fetch-depth: 1
      - name: Copy To Branches Action
        uses: planetoftheweb/copy-to-branches@v1
        env:
          # The branch where the files will be copied from
          key: master
          # The destination branch
          branches: gh-pages
          # The files that will be copied
          files: README.md www/DirSynch-help.html
```

After some tests to figure out why this error was happening, I found out that it's needed to perform a `git fetch` before trying to do a `git checkout -b`.

I made that change and run the action from my forked repo and it worked.

You can see the last run of the action in this repository:
https://github.com/itamarc/dirsynch/actions

As I want to use your action in combination with one I'm creating, I'm sending this pull request to fix this problem in your repo.